### PR TITLE
Moved from python36 to python38

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN yum makecache --timer \
       sudo \
       which \
       hostname \
-      python3 \
+      python38 \
  && yum clean all
 
 # Install Ansible via Pip.


### PR DESCRIPTION
Pip3 cannot install ansible-2.10.7.tar.gz anymore with ubi8 python 3.6, just change with python38 to solve it. 